### PR TITLE
Removed or silenced all but critical edge case errors in persistence controller.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 ==================
 
+1.2.0 (Pre-release)
+==================
+* [Feature] Delegate callbacks for auto-save pre/post/fail
+* [Refactor] Reduce log messages and fix log message format
+
 1.1.0 (2015-09-21)
 ==================
 * [Feature] Added support for tracking item removal through a new change notification. Deprecated existing notification.

--- a/YMCache/YMCachePersistenceController.h
+++ b/YMCache/YMCachePersistenceController.h
@@ -16,6 +16,33 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable NSDictionary *)persistenceController:(YMCachePersistenceController *)controller JSONDictionaryFromModel:(id)value
                                            error:(NSError *__nullable*__nullable)error;
 
+@optional
+
+/**
+ *  Optional. Invoked immediately prior to saving the memory cache to disk.  This method will only be
+ *  invoked due to expiration of the `saveInterval`, not if `saveMemoryCache:` is called.
+ *
+ *  @param controller Cache persistence controller
+ */
+- (void)persistenceControllerWillSaveMemoryCache:(YMCachePersistenceController *)controller;
+
+/**
+ *  Optional. Invoked immediately after successfully saving the memory cache to disk. This method will
+ *  only be invoked due to expiration of the `saveInterval`, not if `saveMemoryCache:` is called.
+ *
+ *  @param controller Cache persistence controller
+ */
+- (void)persistenceControllerDidSaveMemoryCache:(YMCachePersistenceController *)controller;
+
+/**
+ *  Optional. Invoked immediately after failing to save the memory cache to disk. This method will
+ *  only be invoked due to expiration of the `saveInterval`, not if `saveMemoryCache:` is called.
+ *
+ *  @param controller   Cache persistence controller
+ *  @param error        The first error that was encountered
+ */
+- (void)persistenceController:(YMCachePersistenceController *)controller didFailToSaveMemoryCacheWithError:(NSError *)error;
+
 @end
 
 @class YMMemoryCache;

--- a/YMCache/YMLog.h
+++ b/YMCache/YMLog.h
@@ -5,19 +5,21 @@
 //compile out any logging for production builds
 #ifndef DEBUG
 
-// no-op both YFLog and NSLog in release mode
-#define YMLog_(lvl, fmt, ...) NSLog
+// no-op both YFLog in release mode
+#define YMLog_(level, fmt, ...)
 
 #else
 
 // define a logging macro that should be used instead of NSLog
 #define YMLOG_ENABLED // use when logging requires non-trivial computation
 
-#define YMLog_(lvl, fmt, ...) NSLog(@"[#lvl] %s " fmt, __FUNCTION__, ##__VA_ARGS__)
+#define YMLOG_PREFIX(level) "[" level "]"
+
+#define YMLog_(level, fmt, ...) NSLog((@YMLOG_PREFIX(level) " %s " fmt), __PRETTY_FUNCTION__, ##__VA_ARGS__)
 
 #endif
 
 
-#define YMLog(fmt, ...)     YMLog_(INFO, fmt, ##__VA_ARGS__)
-#define YMWarn(fmt, ...)    YMLog_(WARN, fmt, ##__VA_ARGS__)
-#define YMError(fmt, ...)   YMLog_(ERROR,fmt, ##__VA_ARGS__)
+#define YMLog(fmt, ...)     YMLog_("INFO", fmt, ##__VA_ARGS__)
+#define YMWarn(fmt, ...)    YMLog_("WARN", fmt, ##__VA_ARGS__)
+#define YMError(fmt, ...)   YMLog_("ERROR",fmt, ##__VA_ARGS__)


### PR DESCRIPTION
Auto-save processing and errors are now reported to the delegate via
optional callbacks. This allows clients to do their own logging or other
analytics/reporting.