### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ YMMemoryCache *cache = [YMMemoryCache memoryCacheWithName:@"my-object-cache"
     [self.cache purgeEvictableItems:nil];
 }
 ```
-The eviction decider blocks that react to low memory situations will execute on the main thread becasue that is the only thread that sends low memory notifications or calls `-didReceiveMemoryWarning`.
+The eviction decider blocks that react to low memory situations will execute on the main thread because that is the only thread that sends low memory notifications or calls `-didReceiveMemoryWarning`.
 
 #### Observing Changes
 ```objc


### PR DESCRIPTION
@yahoo, I've corrected a typographical error in the documentation of the [YMCache](https://github.com/yahoo/YMCache) project. Specifically, I've changed becasue to because. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.