### PR TITLE
Crash on cache eviction

### DIFF
--- a/YMCache/YMMemoryCache.m
+++ b/YMCache/YMMemoryCache.m
@@ -23,8 +23,11 @@ CFStringRef kYFPrivateQueueKey = CFSTR("kYFPrivateQueueKey");
 @property (nonatomic) dispatch_queue_t queue;
 @property (nonatomic) dispatch_source_t notificationTimer;
 @property (nonatomic) dispatch_source_t evictionTimer;
+/// All of the key-value pairs stored in the cache
 @property (nonatomic) NSMutableDictionary *items;
+/// The keys (and their current value) that have been added/updated since the last kYFCacheDidChangeNotification
 @property (nonatomic) NSMutableDictionary *updatedPendingNotify;
+/// The keys that have been removed since the last kYFCacheDidChangeNotification
 @property (nonatomic) NSMutableSet *removedPendingNotify;
 
 @property (nonatomic, copy) YMMemoryCacheEvictionDecider evictionDecider;

--- a/YMCache/YMMemoryCache.m
+++ b/YMCache/YMMemoryCache.m
@@ -197,12 +197,13 @@ CFStringRef kYFPrivateQueueKey = CFSTR("kYFPrivateQueueKey");
     dispatch_barrier_async(self.queue, ^{
         if (obj) {
             [weakSelf.removedPendingNotify removeObject:key];
+            weakSelf.items[key] = obj;
+            weakSelf.updatedPendingNotify[key] = obj;
         } else if (weakSelf.items[key]) { // removing existing key
             [weakSelf.removedPendingNotify addObject:key];
+            [weakSelf.items removeObjectForKey:key];
+            [weakSelf.updatedPendingNotify removeObjectForKey:key];
         }
-        
-        weakSelf.items[key] = obj;
-        weakSelf.updatedPendingNotify[key] = obj;
     });
 }
 
@@ -213,7 +214,7 @@ CFStringRef kYFPrivateQueueKey = CFSTR("kYFPrivateQueueKey");
     
     dispatch_barrier_sync(self.queue, ^{
         for (id key in self.items) {
-            self.updatedPendingNotify[key] = nil;
+            [self.updatedPendingNotify removeObjectForKey:key];
             [self.removedPendingNotify addObject:key];
         }
         
@@ -232,8 +233,8 @@ CFStringRef kYFPrivateQueueKey = CFSTR("kYFPrivateQueueKey");
         for (id key in keys) {
             if (self.items[key]) {
                 [self.removedPendingNotify addObject:key];
-                self.updatedPendingNotify[key] = nil;
-                self.items[key] = nil;
+                [self.updatedPendingNotify removeObjectForKey:key];
+                [self.items removeObjectForKey:key];
             }
         }
     });


### PR DESCRIPTION
`YMMemoryCache` seems broken. The [documentation for NSMutableDictionary setObject:forKeyedSubscript:](https://developer.apple.com/library/prerelease/ios//documentation/Cocoa/Reference/Foundation/Classes/NSMutableDictionary_Class/index.html#//apple_ref/occ/instm/NSMutableDictionary/setObject:forKeyedSubscript:) says

> "IMPORTANT Raises an NSInvalidArgumentException if anObject is nil."

However, there are several places where the code explicitly uses keyed subscripting to try to set an object to `nil` to clear it out. For example `removeObjectsForKeys:`

I was going to write a unit test that shows this behavior, but the existing tests already fail due to this: 

    Test Case '-[YMMemoryCacheSpecSpec test_YMMemoryCache__Single_setter__Should_unset_value_via_keyed_subscripting]' started.
    2015-10-12 17:52:02.190 xctest[16403:178104] *** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '*** setObjectForKey: object cannot be nil (key: Key2)'

I'm using Xcode 6.4, developing against iOS 8.x with Objective-C, but I can't find any documentation (neither iOS 9 nor Mac) that says this is allowed.

I noticed the problem the first time I evicted my cache: it immediately crashed. The YMMemoryCache documentation says the cache allows setting nil objects, but since it passes the object directly to NSMutableDictionary, I think that's broken too.

Am I missing something? Thanks!