### PR TITLE
Expose NSDataWritingOptions to the client.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 CHANGELOG
 ==================
 
+1.3.0 (2015-10-19)
+==================
+* [Feature] Expose `NSDataWritingOptions` to clients (adds support for encryption on iOS)
+
 1.2.2 (2015-10-12)
 ==================
 * [Bug] iOS 7 crasher upon removing any single value from the cache (@e28eta)
@@ -34,5 +38,4 @@ CHANGELOG
 
 1.0.0 (2015-08-01)
 ==================
-
 * Initial public release of library (@adamkaplan)

--- a/README.md
+++ b/README.md
@@ -148,6 +148,10 @@ cache[@"Key"] = value;
 }
 ```
 
+### File Encryption (iOS) and writing options
+
+The `YMCachePersistenceManager` uses `NSData` to read and write data to disk. By default, we write atomically. You may control write options by setting the persistence manager's `fileWritingOptions` property before the next write.
+
 ### Examples
 
 To run the example projects, clone the repo, and run `pod install` from one of the directories in Example.

--- a/YMCache/YMCachePersistenceController.h
+++ b/YMCache/YMCachePersistenceController.h
@@ -67,7 +67,9 @@ NS_ASSUME_NONNULL_BEGIN
 /** The interval after which  `saveMemoryCache` will be automatically called. Set to 0 or negative to disable automatic saving. */
 @property (nonatomic) NSTimeInterval saveInterval;
 
-/** The options to pass to `-[NSData writeToFile:options:error:]` when saving the cache to disk */
+/** The options to pass to `-[NSData writeToFile:options:error:]` when saving the cache to disk. Default
+ *  is `NSDataWritingAtomic`.
+ */
 @property (nonatomic) NSDataWritingOptions fileWritingOptions;
 
 - (instancetype)init NS_UNAVAILABLE;

--- a/YMCache/YMCachePersistenceController.h
+++ b/YMCache/YMCachePersistenceController.h
@@ -67,6 +67,9 @@ NS_ASSUME_NONNULL_BEGIN
 /** The interval after which  `saveMemoryCache` will be automatically called. Set to 0 or negative to disable automatic saving. */
 @property (nonatomic) NSTimeInterval saveInterval;
 
+/** The options to pass to `-[NSData writeToFile:options:error:]` when saving the cache to disk */
+@property (nonatomic) NSDataWritingOptions fileWritingOptions;
+
 - (instancetype)init NS_UNAVAILABLE;
 
 /** Returns a directory suitable for cache file operations.

--- a/YMCache/YMCachePersistenceController.m
+++ b/YMCache/YMCachePersistenceController.m
@@ -45,6 +45,7 @@ static NSString *const kYFCachePersistenceErrorDomain = @"YFCachePersistenceErro
         _modelClass = modelClass;
         _cacheFileURL = cacheFileURL;
         _serializionDelegate = serializionDelegate;
+        _fileWritingOptions = NSDataWritingAtomic;
         
         NSString *queueName = @"com.yahoo.persist";
         if (cache.name) {
@@ -239,12 +240,7 @@ static NSString *const kYFCachePersistenceErrorDomain = @"YFCachePersistenceErro
         return NO;
     }
     
-    // File protection is only supported on iOS.
-    // TODO: allow these to be provided by the client.
-    NSDataWritingOptions dataWritingOpts = NSDataWritingAtomic;
-#if TARGET_OS_IPHONE
-    dataWritingOpts |= NSDataWritingFileProtectionNone;
-#endif
+    NSDataWritingOptions dataWritingOpts = self.fileWritingOptions;
     
     BOOL success = [data writeToURL:self.cacheFileURL options:dataWritingOpts error:&localError];
     if (localError) {

--- a/YMCache/YMCachePersistenceController.m
+++ b/YMCache/YMCachePersistenceController.m
@@ -240,9 +240,7 @@ static NSString *const kYFCachePersistenceErrorDomain = @"YFCachePersistenceErro
         return NO;
     }
     
-    NSDataWritingOptions dataWritingOpts = self.fileWritingOptions;
-    
-    BOOL success = [data writeToURL:self.cacheFileURL options:dataWritingOpts error:&localError];
+    BOOL success = [data writeToURL:self.cacheFileURL options:self.fileWritingOptions error:&localError];
     if (localError) {
         if (error) {
             *error = localError;


### PR DESCRIPTION
 Default is `NSDataWritingAtomic`. Clients can use this to remove that option, or to
control file encryption (iOS Only)