### PR TITLE
change @import to #import in order to work with ObjC++

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 CHANGELOG
 ==================
 
+1.3.1 ()
+==================
+* [Feature] Remove use of `@import` in order to support ObjC++
+
 1.3.0 (2015-10-19)
 ==================
 * [Feature] Expose `NSDataWritingOptions` to clients (adds support for encryption on iOS)

--- a/YMCache.podspec
+++ b/YMCache.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "YMCache"
-  s.version          = "1.2.2"
+  s.version          = "1.3.1"
   s.summary          = "Fast & simple small object cache. GCD-based and thread-safe."
   s.homepage         = "https://github.com/yahoo/YMCache"
   s.license          = 'MIT'

--- a/YMCache/YMCache.h
+++ b/YMCache/YMCache.h
@@ -1,7 +1,7 @@
 //  Created by Adam Kaplan on 8/1/15.
 //  Copyright 2015 Yahoo.
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 //! Project version number for YMCache.
 FOUNDATION_EXPORT double YMCacheVersionNumber;

--- a/YMCache/YMCachePersistenceController.h
+++ b/YMCache/YMCachePersistenceController.h
@@ -2,7 +2,7 @@
 //  Copyright 2015 Yahoo.
 //  Licensed under the terms of the MIT License. See LICENSE file in the project root.
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/YMCache/YMMemoryCache.h
+++ b/YMCache/YMMemoryCache.h
@@ -2,7 +2,7 @@
 //  Copyright 2015 Yahoo.
 //  Licensed under the terms of the MIT License. See LICENSE file in the project root.
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/YMCacheTests/Tests-Prefix.pch
+++ b/YMCacheTests/Tests-Prefix.pch
@@ -2,7 +2,7 @@
 
 #ifdef __OBJC__
 
-@import Specta;
-@import Expecta;
+#import <Specta/Specta.h>
+#import <Expecta/Expecta.h>
 
 #endif


### PR DESCRIPTION
Removing `@import` in favor of the old fashioned `#import` for projects that have modules disabled (e.g. when using objc++)