### PR TITLE
deprecation message for the notification name had an invalid comment

### DIFF
--- a/YMCache/YMMemoryCache.h
+++ b/YMCache/YMMemoryCache.h
@@ -7,7 +7,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 extern NSString *const kYFCacheItemsChangedNotificationKey
-    __attribute__((deprecated("Since YMCache 1.1.0; Use kYFCacheUpdateNotificationKey instead.")));
+    __attribute__((deprecated("Since YMCache 1.1.0; Use kYFCacheDidChangeNotification instead.")));
 
 /**
  *  Cache update notification. The userInfo dictionary in the notification contains two values:


### PR DESCRIPTION
`kYFCacheUpdateNotificationKey` does not exist anywhere. Looks like you may have changed the name after you added the deprecation warning.