### PR TITLE
YMCachePersistenceController now throws an exception if the 3 required

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode7
+osx_image: xcode8
 xcode_project: YMCache.xcodeproj
 xcode_scheme: YMCache-iOS
 before_install:

--- a/YMCache.xcodeproj/project.pbxproj
+++ b/YMCache.xcodeproj/project.pbxproj
@@ -25,8 +25,8 @@
 		FC59B4561B713FC800093177 /* Specta.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = FC59B4121B71359700093177 /* Specta.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		FC59B4581B713FF000093177 /* Expecta.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = FC59B4151B7135A200093177 /* Expecta.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		FC59B4591B713FF000093177 /* Specta.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = FC59B4161B7135A200093177 /* Specta.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		FCD375111BACF80E0034AD3B /* NSRunLoop+AsyncTestAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = FCD375101BACF80E0034AD3B /* NSRunLoop+AsyncTestAdditions.m */; settings = {ASSET_TAGS = (); }; };
-		FCD375121BACF80E0034AD3B /* NSRunLoop+AsyncTestAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = FCD375101BACF80E0034AD3B /* NSRunLoop+AsyncTestAdditions.m */; settings = {ASSET_TAGS = (); }; };
+		FCD375111BACF80E0034AD3B /* NSRunLoop+AsyncTestAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = FCD375101BACF80E0034AD3B /* NSRunLoop+AsyncTestAdditions.m */; };
+		FCD375121BACF80E0034AD3B /* NSRunLoop+AsyncTestAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = FCD375101BACF80E0034AD3B /* NSRunLoop+AsyncTestAdditions.m */; };
 		FCD690821B710F520099E854 /* YMCachePersistenceController.m in Sources */ = {isa = PBXBuildFile; fileRef = FCB05DDB1B6FDFC300C7302B /* YMCachePersistenceController.m */; };
 		FCD690831B710F540099E854 /* YMMemoryCache.m in Sources */ = {isa = PBXBuildFile; fileRef = FCB05DDE1B6FDFC300C7302B /* YMMemoryCache.m */; };
 		FCD690841B710F5C0099E854 /* YMCache.h in Headers */ = {isa = PBXBuildFile; fileRef = FCDDAB611B7008D4006C333F /* YMCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -378,7 +378,7 @@
 			isa = PBXProject;
 			attributes = {
 				CLASSPREFIX = YM;
-				LastUpgradeCheck = 0700;
+				LastUpgradeCheck = 0800;
 				ORGANIZATIONNAME = "Yahoo, Inc";
 				TargetAttributes = {
 					FC59B3621B71156B00093177 = {
@@ -514,8 +514,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
@@ -535,6 +537,7 @@
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_PEDANTIC = YES;
 				GCC_WARN_UNDECLARED_SELECTOR = YES;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
@@ -550,7 +553,7 @@
 		FC4B27551BA13A2000F870A1 /* Test */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -742,8 +745,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
@@ -763,6 +768,7 @@
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_PEDANTIC = YES;
 				GCC_WARN_UNDECLARED_SELECTOR = YES;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
@@ -788,8 +794,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
@@ -802,6 +810,7 @@
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_PEDANTIC = YES;
 				GCC_WARN_UNDECLARED_SELECTOR = YES;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
@@ -817,7 +826,7 @@
 		FCDDAB711B7008D4006C333F /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -842,7 +851,7 @@
 		FCDDAB721B7008D4006C333F /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;

--- a/YMCache.xcodeproj/xcshareddata/xcschemes/YMCache-Mac.xcscheme
+++ b/YMCache.xcodeproj/xcshareddata/xcschemes/YMCache-Mac.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0700"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/YMCache.xcodeproj/xcshareddata/xcschemes/YMCache-iOS.xcscheme
+++ b/YMCache.xcodeproj/xcshareddata/xcschemes/YMCache-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0700"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/YMCache/YMCachePersistenceController.m
+++ b/YMCache/YMCachePersistenceController.m
@@ -21,7 +21,7 @@ static NSString *const kYFCachePersistenceErrorDomain = @"YFCachePersistenceErro
 + (NSURL *)defaultCacheDirectory {
     NSArray *urls = [[NSFileManager defaultManager] URLsForDirectory:NSDocumentDirectory inDomains:NSUserDomainMask];
     if (!urls.count) {
-        NSAssert(false, @"Unable to find suitable cache directory URL");
+        NSAssert(false, @"%@", @"Unable to find suitable cache directory URL");
         return nil;
     }
     return [urls lastObject];
@@ -111,7 +111,7 @@ static NSString *const kYFCachePersistenceErrorDomain = @"YFCachePersistenceErro
             
             dispatch_source_t timer = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, self.updateQueue);
             dispatch_source_set_timer(timer, DISPATCH_TIME_NOW, saveInterval * NSEC_PER_SEC, 0.1 * NSEC_PER_SEC);
-            __weak typeof(self) weakSelf = self;
+            __weak __typeof__(self) weakSelf = self;
             dispatch_source_set_event_handler(timer, ^{
                 if ([weakSelf.serializionDelegate respondsToSelector:@selector(persistenceControllerWillSaveMemoryCache:)]) {
                     [weakSelf.serializionDelegate persistenceControllerWillSaveMemoryCache:weakSelf];

--- a/YMCache/YMCachePersistenceController.m
+++ b/YMCache/YMCachePersistenceController.m
@@ -32,10 +32,29 @@ static NSString *const kYFCachePersistenceErrorDomain = @"YFCachePersistenceErro
                      delegate:(id<YMSerializationDelegate>)serializionDelegate
                       fileURL:(NSURL *)cacheFileURL {
     NSParameterAssert(cache);
-    NSParameterAssert(modelClass);
     NSParameterAssert(serializionDelegate);
     NSParameterAssert(cacheFileURL);
-    if (!cache || !modelClass || !cacheFileURL || !serializionDelegate) {
+    if (!cache || !cacheFileURL || !serializionDelegate) {
+        // If any of these variables are nil, the persistence controller cannot do it's job.
+        NSString *exceptionReason;
+        if (!cache) {
+            exceptionReason = @"A cache is required to use cache persistence controller.";
+        }
+        
+        if (!cacheFileURL) {
+            exceptionReason = @"The cache file URL is required to use cache persistence controller."
+            @" If the cache is not meant to be stored in a file, do not use a persistence controller.";
+        }
+        
+        if (!serializionDelegate) {
+            exceptionReason = @"Serialization delegate is required for the persistence controller to "
+            @"map between representations of the cache data between file and memory.";
+        }
+        
+        @throw [NSException exceptionWithName:@"InvalidParameterException"
+                                       reason:exceptionReason
+                                     userInfo:nil];
+        
         return nil;
     }
     

--- a/YMCache/YMMemoryCache.m
+++ b/YMCache/YMMemoryCache.m
@@ -130,7 +130,7 @@ CFStringRef kYFPrivateQueueKey = CFSTR("kYFPrivateQueueKey");
         if (evictionInterval > 0) {
             self.evictionTimer = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, self.evictionDeciderQueue);
             
-            __weak typeof(self) weakSelf = self;
+            __weak __typeof(self) weakSelf = self;
             dispatch_source_set_event_handler(self.evictionTimer, ^{ [weakSelf purgeEvictableItems:NULL]; });
             
             dispatch_source_set_timer(_evictionTimer,
@@ -159,7 +159,7 @@ CFStringRef kYFPrivateQueueKey = CFSTR("kYFPrivateQueueKey");
             
             self.notificationTimer = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, self.queue);
             
-            __weak typeof(self) weakSelf = self;
+            __weak __typeof(self) weakSelf = self;
             dispatch_source_set_event_handler(self.notificationTimer, ^{
                 [weakSelf sendPendingNotifications];
             });
@@ -193,7 +193,7 @@ CFStringRef kYFPrivateQueueKey = CFSTR("kYFPrivateQueueKey");
 - (void)setObject:(id)obj forKeyedSubscript:(id)key {
     NSParameterAssert(key); // The collections will assert, but fail earlier to aid in async debugging
     
-    __weak typeof(self) weakSelf = self;
+    __weak __typeof(self) weakSelf = self;
     dispatch_barrier_async(self.queue, ^{
         if (obj) {
             [weakSelf.removedPendingNotify removeObject:key];

--- a/YMCacheTests/YMCachePersistenceControllerSpec.m
+++ b/YMCacheTests/YMCachePersistenceControllerSpec.m
@@ -52,61 +52,86 @@ describe(@"YMCachePersistenceControllerSpec", ^{
         expect(expectUrl).to.equal(gotUrl);
     });
     
-    context(@"Default initializer", ^{
+    describe(@"Default initializer", ^{
         
-        it(@"return nil if arguments are not valid", ^{
-            id obj;
-
-            YMMemoryCache *cache = nil;
-            Class class = [NSObject class];
-            id<YMSerializationDelegate> delegate = [TestDelegate new];
-            NSURL *fileUrl = [NSURL URLWithString:@"file:///"];
-            
-            obj = [[YMCachePersistenceController alloc] initWithCache:cache
-                                                           modelClass:class
-                                                             delegate:delegate
-                                                              fileURL:fileUrl];
-            expect(obj).to.beNil();
-            
+        __block YMMemoryCache *cache;
+        __block Class class;
+        __block id<YMSerializationDelegate> delegate;
+        __block NSURL *fileUrl;
+        
+        beforeEach(^{
             cache = [[YMMemoryCache alloc] initWithName:@"Name" evictionDecider:nil];
-            class = nil;
-            obj = [[YMCachePersistenceController alloc] initWithCache:cache
-                                                           modelClass:class
-                                                             delegate:delegate
-                                                              fileURL:fileUrl];
-            expect(obj).to.beNil();
-
             class = [NSObject class];
-            delegate = nil;
-            obj = [[YMCachePersistenceController alloc] initWithCache:cache
-                                                           modelClass:class
-                                                             delegate:delegate
-                                                              fileURL:fileUrl];
-            expect(obj).to.beNil();
-            
             delegate = [TestDelegate new];
-            fileUrl = nil;
-            obj = [[YMCachePersistenceController alloc] initWithCache:cache
-                                                           modelClass:class
-                                                             delegate:delegate
-                                                              fileURL:fileUrl];
-            expect(obj).to.beNil();
+            fileUrl = [NSURL URLWithString:@"file:///"];
         });
         
-        it(@"correctly set all initial values", ^{
-            YMMemoryCache *cache = [[YMMemoryCache alloc] initWithName:@"Name" evictionDecider:nil];
-            Class class = [NSObject class];
-            id<YMSerializationDelegate> delegate = [TestDelegate new];
-            NSURL *fileUrl = [NSURL URLWithString:@"file:///"];
+        context(@"required args", ^{
+            __block id unused;
             
-            YMCachePersistenceController *con = [[YMCachePersistenceController alloc] initWithCache:cache
-                                                                                         modelClass:class
-                                                                                           delegate:delegate
-                                                                                            fileURL:fileUrl];
-            expect(con.cache).to.beIdenticalTo(cache);
-            expect(con.modelClass).to.beIdenticalTo(class);
-            expect(con.serializionDelegate).to.beIdenticalTo(delegate);
-            expect(con.cacheFileURL).to.equal(fileUrl);
+            it(@"throws exception if cache is nil", ^{
+                cache = nil;
+                expect(^{
+                    unused = [[YMCachePersistenceController alloc] initWithCache:cache
+                                                                      modelClass:class
+                                                                        delegate:delegate
+                                                                         fileURL:fileUrl];
+                }).to.raiseWithReason(@"InvalidParameterException",
+                                      @"A cache is required to use cache persistence controller.");
+            });
+            
+            it(@"throws exception if delegate is nil", ^{
+                delegate = nil;
+                expect(^{
+                    unused = [[YMCachePersistenceController alloc] initWithCache:cache
+                                                                      modelClass:class
+                                                                        delegate:delegate
+                                                                         fileURL:fileUrl];
+                }).to.raiseWithReason(@"InvalidParameterException",
+                                      @"Serialization delegate is required for the persistence controller to "
+                                      @"map between representations of the cache data between file and memory.");
+            });
+            
+            it(@"throws exception if fileURL is nil", ^{
+                fileUrl = nil;
+                expect(^{
+                    unused = [[YMCachePersistenceController alloc] initWithCache:cache
+                                                                      modelClass:class
+                                                                        delegate:delegate
+                                                                         fileURL:fileUrl];
+                }).to.raiseWithReason(@"InvalidParameterException",
+                                      @"The cache file URL is required to use cache persistence controller."
+                                      @" If the cache is not meant to be stored in a file, do not use a"
+                                      @" persistence controller.");
+            });
+        });
+        
+        context(@"correctly set initial values", ^{
+            
+            it(@"sets all values", ^{
+                YMCachePersistenceController *con = [[YMCachePersistenceController alloc] initWithCache:cache
+                                                                                             modelClass:class
+                                                                                               delegate:delegate
+                                                                                                fileURL:fileUrl];
+                expect(con.cache).to.beIdenticalTo(cache);
+                expect(con.modelClass).to.beIdenticalTo(class);
+                expect(con.serializionDelegate).to.beIdenticalTo(delegate);
+                expect(con.cacheFileURL).to.equal(fileUrl);
+            });
+            
+            it(@"sets minimum values", ^{
+                class = nil;
+                
+                YMCachePersistenceController *con = [[YMCachePersistenceController alloc] initWithCache:cache
+                                                                                             modelClass:class
+                                                                                               delegate:delegate
+                                                                                                fileURL:fileUrl];
+                expect(con.cache).to.beIdenticalTo(cache);
+                expect(con.modelClass).to.beNil();
+                expect(con.serializionDelegate).to.beIdenticalTo(delegate);
+                expect(con.cacheFileURL).to.equal(fileUrl);
+            });
+            
         });
         
     });


### PR DESCRIPTION
parameters are missing. This prevents errors from being missed, since
the initialier was returning nil - and nobody checks for that.