### PR TITLE
Set YMCache iOS target to allow only extension API

### DIFF
--- a/YMCache.xcodeproj/project.pbxproj
+++ b/YMCache.xcodeproj/project.pbxproj
@@ -565,6 +565,7 @@
 		FC4B27551BA13A2000F870A1 /* Test */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
@@ -862,6 +863,7 @@
 		FCDDAB711B7008D4006C333F /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
@@ -887,6 +889,7 @@
 		FCDDAB721B7008D4006C333F /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;


### PR DESCRIPTION
This silences warnings about potentially unsafe dependencies when
including in an extension. Also, YMCache iOS should always be
kep extension-safe.