### PR TITLE
Unit tests & corner case check for loading-getter

### DIFF
--- a/YMCache/YMMemoryCache.h
+++ b/YMCache/YMMemoryCache.h
@@ -107,7 +107,9 @@ typedef __nullable id (^YMMemoryCacheObjectLoader)();
  */
 - (nullable id)objectForKeyedSubscript:(nonnull id)key;
 
-/** Get the value for the key. If no value exists, invokes defaultLoader(), sets the result as the value for key, and returns it.
+/** Get the value for the key. If value does not exist, invokes defaultLoader(), sets the result as
+ the value for key, and returns it. In order to ensure consistency, the cache is locked when
+ the defaultLoader block needs to be invoked.
  */
 - (nullable id)objectForKey:(NSString *)key withDefault:(YMMemoryCacheObjectLoader)defaultLoader;
 


### PR DESCRIPTION
Added unit tests for existing code.
Tweaked docs to call out that the block is executing during full-lock – so I needs to be fast and can't call the cache again.