### PR TITLE
Update YMCache.h to include the publicly available YMLog.h

### DIFF
--- a/YMCache/YMCache.h
+++ b/YMCache/YMCache.h
@@ -11,4 +11,4 @@ FOUNDATION_EXPORT const unsigned char YMCacheVersionString[];
 
 #import "YMMemoryCache.h"
 #import "YMCachePersistenceController.h"
-
+#import "YMLog.h"


### PR DESCRIPTION
<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

When a public header is named with the same as the module, Swift Package Manager interprets this as opting out of automatic umbrella header generation and will use said header as the umbrella header instead. In this case, `YMCache.h` is the umbrella header as far as SwiftPM is concerned. As such, it therefore must import all headers which are public.

<img width="684" alt="Screen Shot 2023-02-07 at 7 15 54 PM" src="https://user-images.githubusercontent.com/987706/217419910-db371f87-5b02-40b7-8b2c-aca7b3dfccab.png">

